### PR TITLE
:add: fast snapshot

### DIFF
--- a/app/api/v1/routes/staking.py
+++ b/app/api/v1/routes/staking.py
@@ -1,5 +1,5 @@
 import requests
-from starlette.responses import JSONResponse 
+from starlette.responses import JSONResponse
 from wallet import Wallet
 from config import Config, Network # api specific config
 from fastapi import APIRouter, status
@@ -13,6 +13,7 @@ from hashlib import blake2b
 from api.v1.routes.blockchain import TXFormat, getInputBoxes, getNFTBox, getTokenBoxes, getTokenInfo, getErgoscript, getBoxesWithUnspentTokens
 from hashlib import blake2b
 from cache.cache import cache
+from cache.staking import AsyncSnapshotEngine 
 
 staking_router = r = APIRouter()
 
@@ -208,34 +209,42 @@ async def unstake(req: UnstakeRequest):
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Undefined error during unstaking')
 
 
-
 @r.get("/snapshot/", name="staking:snapshot")
 def snapshot():
     try:
         offset = 0
         limit = 100
         done = False
-        addresses = {}
+
+        # Faster API Calls
+        engine = AsyncSnapshotEngine()
+
         while not done:
-            checkBoxes = getTokenBoxes(tokenId=CFG.stakeTokenID,offset=offset,limit=limit)
+            checkBoxes = getTokenBoxes(
+                tokenId=CFG.stakeTokenID, offset=offset, limit=limit)
             for box in checkBoxes:
-                if box["assets"][0]["tokenId"]==CFG.stakeTokenID:
-                    keyHolder = getNFTBox(box["additionalRegisters"]["R5"]["renderedValue"])
-                    if keyHolder is None:
-                        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Unable to fetch stake key box')
-                    if keyHolder["address"] not in addresses.keys():
-                        addresses[keyHolder["address"]] = 0
-                    addresses[keyHolder["address"]] += (box["assets"][1]["amount"]/10**2)
-            if len(checkBoxes)<limit:
-                done=True
+                if box["assets"][0]["tokenId"] == CFG.stakeTokenID:
+                    tokenId = box["additionalRegisters"]["R5"]["renderedValue"]
+                    amount = int(box["assets"][1]["amount"]) / 10**2
+                    engine.add_job(tokenId, amount)
+            
+            engine.compute()
+            if len(checkBoxes) < limit:
+                done = True
             offset += limit
-        
-        return {
-            'stakers': addresses
-        }
+
+        data = engine.get()
+        if data != None:
+            return {
+                'stakers': data
+            }
+        else:
+            return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Unable to fetch stake key box')
+
     except Exception as e:
         logging.error(f'ERR:{myself()}: ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Undefined error during snapshot')
+
 
 def validPenalty(startTime: int):
     currentTime = int(time()*1000)

--- a/app/cache/staking.py
+++ b/app/cache/staking.py
@@ -1,0 +1,89 @@
+import threading
+
+from api.v1.routes.blockchain import getNFTBox
+
+
+class SyncMap:
+    def __init__(self):
+        self.errored = False
+        self.data = dict()
+        self.lock = threading.Lock()
+
+    def increment(self, key, value):
+        # thread safe increment
+        self.lock.acquire()
+        if key not in self.data:
+            self.data[key] = 0
+        self.data[key] += value
+        self.lock.release()
+
+    def error(self):
+        # thread safe error
+        self.lock.acquire()
+        self.errored = True
+        self.lock.release()
+
+    def get_error(self):
+        return self.errored
+
+    def get_data(self):
+        return self.data
+
+
+# Parallize the following code from staking.py
+"""
+keyHolder = getNFTBox(box["additionalRegisters"]["R5"]["renderedValue"])
+if keyHolder is None:
+    return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Unable to fetch stake key box')
+if keyHolder["address"] not in addresses.keys():
+    addresses[keyHolder["address"]] = 0
+addresses[keyHolder["address"]] += (box["assets"][1]["amount"]/10**2)
+"""
+
+
+class AsyncSnapshotEngine:
+    THREAD_COUNT = 16
+
+    def __init__(self):
+        self.output = SyncMap()
+        self.inputs = list()
+
+    def add_job(self, token_id, amount):
+        self.inputs.append((token_id, amount))
+
+    def handle_nft_box(self, token_id, amount):
+        key_holder = getNFTBox(token_id, True)
+        if (key_holder):
+            self.output.increment(key_holder["address"], amount)
+        else:
+            self.output.error()
+
+    def compute(self):
+        # warm up cache
+        batch = self.inputs[:1]
+        for inp in batch:
+            t = threading.Thread(
+                target=self.handle_nft_box, args=inp)
+            t.start()
+            t.join()
+
+        for start in range(1, len(self.inputs), AsyncSnapshotEngine.THREAD_COUNT):
+            batch = self.inputs[start: start +
+                                AsyncSnapshotEngine.THREAD_COUNT]
+            threads = []
+            for inp in batch:
+                threads.append(threading.Thread(
+                    target=self.handle_nft_box, args=inp))
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        # clear inputs
+        self.inputs = list()
+
+    def get(self):
+        if self.output.get_error():
+            return None
+        else:
+            return self.output.get_data()


### PR DESCRIPTION
## FAST SNAPSHOT
```
> THREAD_COUNT = 16
```

Notes:
- getNFTBox will use cached data for snapshot call ```mempool/boxes/unspent```, this will not effect other calls as allowCached defaults false

## EXPERIMENTAL
- ### TEST LOCALLY BEFORE DEPLOYMENT
- ### average response time for ```/staking/snapshot``` reduces to approx 100 seconds