### PR TITLE
:update: getTokenBoxes and :fix: for snapshot to handle burnt keys

### DIFF
--- a/app/api/v1/routes/blockchain.py
+++ b/app/api/v1/routes/blockchain.py
@@ -359,7 +359,7 @@ def getNFTBox(tokenId: str, allowCached=False):
                     "ok": ok,
                     "memResContent": memResContent
                 }
-                cache.set("get_explorer_mempool_boxes_unspent", content, 300)
+                cache.set("get_explorer_mempool_boxes_unspent", content, 600) # 10 mins
         else:
             # if cached is not allowed force api call
             memRes = requests.get(f'{CFG.explorer}/mempool/boxes/unspent')
@@ -391,11 +391,70 @@ def getNFTBox(tokenId: str, allowCached=False):
             if len(items) == 1:
                 return items[0]
             else:
-                logging.error(f'ERR:{myself()}: multiple nft box ({e})')
+                logging.error(f'ERR:{myself()}: multiple nft box or tokenId doesn\'t exist')
     except Exception as e:
         logging.error(f'ERR:{myself()}: unable to find nft box ({e})')
         return None
 
+# GET unspent boxes by token id direct from explorer db
+def getUnspentStakeKeyTokenBoxes():
+    try:
+        con = create_engine(EXPLORER)
+        sql = f"""
+            -- /unspent/byTokenId (optimized for stakeTokenId)
+            select
+                o.box_id as box_id,
+                -- additional registers in JSON format
+                -- R4 penalty
+                -- R5 stake key
+                o.additional_registers as additional_registers,
+                a.token_id as token_id,
+                -- index of the token in assets list
+                -- 0 stake token
+                -- 1 ergopad staked
+                a.index as index,
+                 -- amount of token in the box
+                a.value as value
+            from
+                node_outputs o
+                join node_assets a on a.box_id = o.box_id
+                and a.header_id = o.header_id
+            where
+                o.box_id in (
+                    -- sub query to get unspent box ids
+                    -- non correlated sub query => executed once
+                    select
+                        o.box_id as box_id
+                    from
+                        node_outputs o
+                        left join node_inputs i on i.box_id = o.box_id
+                        join node_assets a on a.box_id = o.box_id
+                        and a.header_id = o.header_id
+                    where
+                        o.main_chain = true
+                        and i.box_id is null -- output with no input = unspent
+                        and a.token_id = '1028de73d018f0c9a374b71555c5b8f1390994f2f41633e7b9d68f77735782ee' -- stake key token id
+                        and coalesce(a.value, 0) > 0
+                );
+        """
+        res = con.execute(sql).fetchall()
+        boxes = {}
+        for data in res:
+            if data["box_id"] in boxes:
+                boxes[data["box_id"]]["assets"].insert(data["index"], {"tokenId": data["token_id"], "index": data["index"], "amount": data["value"]})
+            else:
+                boxes[data["box_id"]] = {
+                    "boxId": data["box_id"],
+                    "additionalRegisters": data["additional_registers"],
+                    "assets": [{"tokenId": data["token_id"], "index": data["index"], "amount": data["value"]}]
+                }
+        return list(boxes.values())
+        
+    except Exception as e:
+        logging.error(f'ERR:{myself()}: invalid request ({e})')
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content='failed to read data from explorer db')
+
+# legacy code using explorer API
 def getTokenBoxes(tokenId: str, offset: int = 0, limit: int = 100):
     try:
         res = requests.get(f'{CFG.explorer}/boxes/unspent/byTokenId/{tokenId}?offset={offset}&limit={limit}')

--- a/app/api/v1/routes/staking.py
+++ b/app/api/v1/routes/staking.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from base64 import b64encode
 from ergo.util import encodeLongArray, encodeString, hexstringToB64
 from hashlib import blake2b
-from api.v1.routes.blockchain import TXFormat, getInputBoxes, getNFTBox, getTokenBoxes, getTokenInfo, getErgoscript, getBoxesWithUnspentTokens
+from api.v1.routes.blockchain import TXFormat, getInputBoxes, getNFTBox, getTokenInfo, getErgoscript, getBoxesWithUnspentTokens, getUnspentStakeKeyTokenBoxes
 from hashlib import blake2b
 from cache.cache import cache
 from core.auth import get_current_active_superuser, get_current_active_user
@@ -236,40 +236,33 @@ async def unstake(req: UnstakeRequest):
         logging.error(f'ERR:{myself()}: ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Undefined error during unstaking')
 
+
 @r.get("/snapshot/", name="staking:snapshot")
 def snapshot(
     request: Request,
     current_user=Depends(get_current_active_user)
 ):
     try:
-        offset = 0
-        limit = 100
-        done = False
-
         # Faster API Calls
         engine = AsyncSnapshotEngine()
 
-        while not done:
-            checkBoxes = getTokenBoxes(
-                tokenId=CFG.stakeTokenID, offset=offset, limit=limit)
-            for box in checkBoxes:
-                if box["assets"][0]["tokenId"] == CFG.stakeTokenID:
-                    tokenId = box["additionalRegisters"]["R5"]["renderedValue"]
-                    amount = int(box["assets"][1]["amount"]) / 10**2
-                    engine.add_job(tokenId, amount)
-            
-            engine.compute()
-            if len(checkBoxes) < limit:
-                done = True
-            offset += limit
+        checkBoxes = getUnspentStakeKeyTokenBoxes()
+        for box in checkBoxes:
+            if box["assets"][0]["tokenId"] == CFG.stakeTokenID:
+                tokenId = box["additionalRegisters"]["R5"]["renderedValue"]
+                amount = int(box["assets"][1]["amount"]) / 10**2
+                engine.add_job(tokenId, amount)
+
+        engine.compute()
 
         data = engine.get()
         if data != None:
             return {
-                'stakers': data
+                'token_errors': data['errors'],
+                'stakers': data["output"],
             }
         else:
-            return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Unable to fetch stake key box')
+            return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Unable to fetch snapshot')
 
     except Exception as e:
         logging.error(f'ERR:{myself()}: ({e})')
@@ -311,40 +304,34 @@ async def staked(req: AddressList):
             else:
                 return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'Failure to fetch balance for {address}')
         
-        offset = 0
-        limit = 100
-        done = False
         totalStaked = 0
         stakePerAddress = {}
-        while not done:
-            # getTokenBoxes from cache
-            checkBoxes = []
-            cached = cache.get(f"get_staking_staked_token_boxes_{CFG.stakeTokenID}_{offset}_{limit}")
-            if cached:
-                checkBoxes = cached
-            else:
-                checkBoxes = getTokenBoxes(tokenId=CFG.stakeTokenID,offset=offset,limit=limit)
-                cache.set(f"get_staking_staked_token_boxes_{CFG.stakeTokenID}_{offset}_{limit}", checkBoxes, CACHE_TTL)
-            for box in checkBoxes:
-                if box["assets"][0]["tokenId"]==CFG.stakeTokenID:
-                    if box["additionalRegisters"]["R5"]["renderedValue"] in stakeKeys.keys():
-                        if stakeKeys[box["additionalRegisters"]["R5"]["renderedValue"]] not in stakePerAddress:
-                            stakePerAddress[stakeKeys[box["additionalRegisters"]["R5"]["renderedValue"]]] = {'totalStaked': 0, 'stakeBoxes': []}
-                        stakeBoxR4 = eval(box["additionalRegisters"]["R4"]["renderedValue"])
-                        cleanedBox = {
-                            'boxId': box["boxId"],
-                            'stakeKeyId': box["additionalRegisters"]["R5"]["renderedValue"],
-                            'stakeAmount': box["assets"][1]["amount"]/10**2,
-                            'penaltyPct': validPenalty(stakeBoxR4[1]),
-                            'penaltyEndTime': int(stakeBoxR4[1]+8*week)
-                        }
-                        stakePerAddress[stakeKeys[box["additionalRegisters"]["R5"]["renderedValue"]]]["stakeBoxes"].append(cleanedBox)
-                        totalStaked += box["assets"][1]["amount"]/10**2
-                        stakePerAddress[stakeKeys[box["additionalRegisters"]["R5"]["renderedValue"]]]["totalStaked"] += box["assets"][1]["amount"]/10**2
-            if len(checkBoxes)<limit:
-                done=True
-            offset += limit
         
+        # getTokenBoxes from cache
+        checkBoxes = []
+        cached = cache.get(f"get_staking_staked_token_boxes_{CFG.stakeTokenID}")
+        if cached:
+            checkBoxes = cached
+        else:
+            checkBoxes = getUnspentStakeKeyTokenBoxes()
+            cache.set(f"get_staking_staked_token_boxes_{CFG.stakeTokenID}", checkBoxes, CACHE_TTL)
+        for box in checkBoxes:
+            if box["assets"][0]["tokenId"]==CFG.stakeTokenID:
+                if box["additionalRegisters"]["R5"]["renderedValue"] in stakeKeys.keys():
+                    if stakeKeys[box["additionalRegisters"]["R5"]["renderedValue"]] not in stakePerAddress:
+                        stakePerAddress[stakeKeys[box["additionalRegisters"]["R5"]["renderedValue"]]] = {'totalStaked': 0, 'stakeBoxes': []}
+                    stakeBoxR4 = eval(box["additionalRegisters"]["R4"]["renderedValue"])
+                    cleanedBox = {
+                        'boxId': box["boxId"],
+                        'stakeKeyId': box["additionalRegisters"]["R5"]["renderedValue"],
+                        'stakeAmount': box["assets"][1]["amount"]/10**2,
+                        'penaltyPct': validPenalty(stakeBoxR4[1]),
+                        'penaltyEndTime': int(stakeBoxR4[1]+8*week)
+                    }
+                    stakePerAddress[stakeKeys[box["additionalRegisters"]["R5"]["renderedValue"]]]["stakeBoxes"].append(cleanedBox)
+                    totalStaked += box["assets"][1]["amount"]/10**2
+                    stakePerAddress[stakeKeys[box["additionalRegisters"]["R5"]["renderedValue"]]]["totalStaked"] += box["assets"][1]["amount"]/10**2
+
         return {
             'totalStaked': totalStaked,
             'addresses': stakePerAddress
@@ -359,7 +346,6 @@ def stakingStatus():
     cached = cache.get(f"get_api_staking_status")
     if cached:
         return cached
-
 
     stakeStateBox = getNFTBox(CFG.stakeStateNFT)
     stakeStateR4 = eval(stakeStateBox["additionalRegisters"]["R4"]["renderedValue"])
@@ -436,51 +422,46 @@ async def compound(
             return {'remainingStakers': 0}
         stakeBoxes = []
         stakeBoxesOutput = []
-        offset = 0
-        limit = 100
         totalReward = 0
 
-        checkBoxes = getTokenBoxes(tokenId=CFG.stakeTokenID,offset=offset,limit=limit)
-        while len(checkBoxes) > 0:
-            for box in checkBoxes:
-                if box["assets"][0]["tokenId"]==CFG.stakeTokenID:
-                    boxR4 = eval(box["additionalRegisters"]["R4"]["renderedValue"])
-                    if boxR4[0] == emissionR4[1]:
-                        stakeBoxes.append(box["boxId"])
-                        stakeReward = int(box["assets"][1]["amount"] * emissionR4[3] / emissionR4[0])
-                        totalReward += stakeReward
-                        stakeBoxesOutput.append({
-                            'value': box["value"],
-                            'address': box["address"],
-                            'assets': [
-                                {                                                                   
-                                    'tokenId': CFG.stakeTokenID,
-                                    'amount': 1
-                                },
-                                {
-                                    'tokenId': CFG.stakedTokenID,
-                                    'amount': box["assets"][1]["amount"] + stakeReward
-                                }
-                            ],
-                            'registers': {
-                                'R4': encodeLongArray([
-                                    boxR4[0]+1,
-                                    boxR4[1]
-                                ]),
-                                'R5': box["additionalRegisters"]["R5"]["serializedValue"]
+        checkBoxes = getUnspentStakeKeyTokenBoxes()
+        for box in checkBoxes:
+            if box["assets"][0]["tokenId"]==CFG.stakeTokenID:
+                boxR4 = eval(box["additionalRegisters"]["R4"]["renderedValue"])
+                if boxR4[0] == emissionR4[1]:
+                    stakeBoxes.append(box["boxId"])
+                    stakeReward = int(box["assets"][1]["amount"] * emissionR4[3] / emissionR4[0])
+                    totalReward += stakeReward
+                    stakeBoxesOutput.append({
+                        'value': box["value"],
+                        'address': box["address"],
+                        'assets': [
+                            {                                                                   
+                                'tokenId': CFG.stakeTokenID,
+                                'amount': 1
+                            },
+                            {
+                                'tokenId': CFG.stakedTokenID,
+                                'amount': box["assets"][1]["amount"] + stakeReward
                             }
-                        })
-                if len(stakeBoxes)>=req.numBoxes:
-                    request = compoundTX(stakeBoxes,stakeBoxesOutput,totalReward,emissionBox,emissionR4)
-                    res = requests.post(f'{CFG.node}/wallet/transaction/send', headers=dict(headers, **{'api_key': req.apiKey}), json=request)
-                    stakeBoxes = []
-                    stakeBoxesOutput = []
-                    totalReward = 0
-                    await asyncio.sleep(10)
-                    emissionBox = getNFTBox(CFG.emissionNFT)
-                    emissionR4 = eval(emissionBox["additionalRegisters"]["R4"]["renderedValue"])
-            offset += limit
-            checkBoxes = getTokenBoxes(tokenId=CFG.stakeTokenID,offset=offset,limit=limit)
+                        ],
+                        'registers': {
+                            'R4': encodeLongArray([
+                                boxR4[0]+1,
+                                boxR4[1]
+                            ]),
+                            'R5': box["additionalRegisters"]["R5"]["serializedValue"]
+                        }
+                    })
+            if len(stakeBoxes)>=req.numBoxes:
+                request = compoundTX(stakeBoxes,stakeBoxesOutput,totalReward,emissionBox,emissionR4)
+                res = requests.post(f'{CFG.node}/wallet/transaction/send', headers=dict(headers, **{'api_key': req.apiKey}), json=request)
+                stakeBoxes = []
+                stakeBoxesOutput = []
+                totalReward = 0
+                await asyncio.sleep(10)
+                emissionBox = getNFTBox(CFG.emissionNFT)
+                emissionR4 = eval(emissionBox["additionalRegisters"]["R4"]["renderedValue"])
 
         if len(stakeBoxes) > 0: 
             request = compoundTX(stakeBoxes,stakeBoxesOutput,totalReward,emissionBox,emissionR4)


### PR DESCRIPTION
# ChangeList
## Update to Snapshot EndPoint
- Some stake keys have been burned and hence get unspent boxes by token id calls returned empty for those ids. The existing snapshot fails in this case.
- Fix for round errors in snapshot
### New Snapshot response example:
```
{
  "token_errors": {
    "18c0df5a674c160e39c4934687ac015d1e25f5dcc760f40ad2fd5a5667ada33a": 1,
    "d4298ff4c8c0dd028b58f2a8a1ce8d8523818e2dce6fa6b140b31a3da9a95ebb": 1,
    "8f1224baab26ca52874b8d4c65818c353ef811509e5bf53b5c7a6ece1ff7e442": 1,
    "75b39acc27106c0e8a4293370f08aa9d1e10d0e2d0cfcdb3a72902a8332bfaa3": 1,
    "b974cede5a162e027bea984ca0372a979963e950d9f8c76d4f20138924ddcd12": 1
  },
  "stakers": {
    "9fXxBX1Rq97SFgPesHEtHLLesENqg69rTb1D3dFHu7V1GJ3Lnv5": 104579.14,
    "9eeJzzUJY5VTTb324rDNskciDdPW969otic4aZ6mt1gJrQHpSnG": 53.11,
    "9hFMt78N9Sis1Y1qaZewb3AHJvYF6sE4JGzeJVG8thE35PJCkgP": 1134.52,
    "9fCGfnNGNw2TTkCE8VuiDPnF4AzUP8RzD1qcZ4fGFbMtPgZ3tKA": 10194.46,
    "9ef5mytzjhDDRcJKxKzGBKQYWXQJ1npExzqUSzwqzbSYnE7ReZk": 827.63,
    "9hVVgQU9L49AWiQ8WJCw4kFcmJKozCvXhHvyzWwoma7CbqN3vhY": 917.82,
    "9hZ9EL3b3RFkiNvoQqasqMR1Wyd9DHid3M22K3KCwhtVRU2v7hR": 9027.59,
    "9gRMibvCPzsZymGKKuhUAWDhTvQi37mrDo9n8BFiEjhn7Xhb85R": 89174.86,
    "9i3AC9YGjJC5aenqrzT8Zr8BRiwTGxKE4K8iQwzq9Ck81s6viyc": 69165.54,
    "9gkiXoyxdukczbiRVR1WX8jEDb2xGrnN9o2e3S8ptfJZppgP6rf": 58.74,
    "9eayp5KZiudis7a81HWZWJe29fvCBsKxeca24v9vZaKb8W8E3hx": 2047,
    "9h2S1RyesWMRdhrUU3DLuZxMTWkEsCQzMM9Qus8RHKKfJUE5zyb": 662.83,
    "9gicpipSQr966cZrD2MwW5cjQw8PdoVAY4FPXcdn3mqWZUAGSCG": 3958.66,
    "9iKyyfKCa2wL4462Rdjth1QHDvyxkrwLW5Hw4qoAWhroFGbx7cK": 18255.35,
    "9fmonodCrMrWwwLzQhsrqibzhDccT8AaixqLjN5NQ5viTL2qTUg": 296677.56,
    "9fHUHhoJQNyzDKt7Zrc7F7bh8UBHzfA5rKBR2zmttNMKqsDZcT6": 663.98,
    "9hoNM75R2zKNZfnrSL5ZaDkAthM7uHUyA8WtSa8pk1rtyP4o82a": 1012.1,
...
```

## Direct DB read for StakeStake Token
### SQL
```
-- /unspent/byTokenId (optimized for stakeTokenId)
select
    o.box_id as box_id,
    -- additional registers in JSON format
    -- R4 penalty
    -- R5 stake key
    o.additional_registers as additional_registers,
    a.token_id as token_id,
    -- index of the token in assets list
    -- 0 stake token
    -- 1 ergopad staked
    a.index as index,
    a.value as value -- amount of token in the box
from
    node_outputs o
    join node_assets a on a.box_id = o.box_id
    and a.header_id = o.header_id
where
    o.box_id in (
        -- sub query to get unspent box ids
        -- non correlated sub query => executed once
        select
            o.box_id as box_id
        from
            node_outputs o
            left join node_inputs i on i.box_id = o.box_id
            join node_assets a on a.box_id = o.box_id
            and a.header_id = o.header_id
        where
            o.main_chain = true
            and i.box_id is null -- output with no input = unspent
            and a.token_id = '1028de73d018f0c9a374b71555c5b8f1390994f2f41633e7b9d68f77735782ee' -- stake key token id
            and coalesce(a.value, 0) > 0
    );
```
- takes around 4.7 seconds compared to 10 (API calls) * 1.5 (per call) seconds previously for 990 boxes
- Output for ```getUnspentStakeKeyTokenBoxes``` follows a similar format to that of the explorer API so minimum exisiting code changes in staking.py
### The following endpoints are effected
- /snapshot [could test locally]
- /staked     [could test locally]
- /compound

### Should test ```compound``` thoroughly before deploying.

## MemPool cache TTL
- snapshot takes around 7-8 mins TTL updated for mempool redis cache to 10 mins from 5 mins previously

## Notes
closes #20
