### PR TITLE
:redirect: paideia

### DIFF
--- a/app/api/v1/routes/asset.py
+++ b/app/api/v1/routes/asset.py
@@ -55,18 +55,12 @@ async def get_asset_balance_from_address(address: str = Path(..., min_length=40,
         # get balance from ergo explorer api
         logging.debug(f'find balance for [blockchain], address: {address}...')
         wallet_assets = {}
-
-        # check cache
-        cached = cache.get(f"get_asset_balance_{address}")
-        if cached:
-            balance = cached
-        else:
-            res = requests.get(
-                f'{CFG.explorer}/addresses/{address}/balance/total')
-            # handle invalid address or other error
-            if res.status_code == 200:
-                balance = res.json()
-                cache.set(f"get_asset_balance_{address}", balance)
+        balance = {}
+        
+        res = requests.get(f'{CFG.explorer}/addresses/{address}/balance/total')
+        # handle invalid address or other error
+        if res.status_code == 200:
+            balance = res.json()
 
         logging.info(f'Balance for ergo: {balance}')
         ergPrice = (await get_asset_current_price('ERGO'))['price']

--- a/app/api/v1/routes/blockchain.py
+++ b/app/api/v1/routes/blockchain.py
@@ -95,6 +95,7 @@ async def getInfo():
         logging.error(f'ERR:{myself()}: invalid blockchain info ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid blockchain info ({e})')
 
+
 # info about token
 @r.get("/tokenInfo/{tokenId}", name="blockchain:tokenInfo")
 def getTokenInfo(tokenId):
@@ -106,6 +107,7 @@ def getTokenInfo(tokenId):
         logging.error(f'ERR:{myself()}: invalid token request ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid token request ({e})')
 
+
 @r.get("/boxInfo/{boxId}", name="blockchain:boxInfo")
 def getBoxInfo(boxId):
     try:
@@ -115,6 +117,7 @@ def getBoxInfo(boxId):
         logging.error(f'ERR:{myself()}: invalid box request ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid box request ({e})')
 
+
 @r.get("/transactionInfo/{transactionId}", name="blockchain:transactionInfo")
 def getTransactionInfo(transactionId):
     try:
@@ -123,6 +126,7 @@ def getTransactionInfo(transactionId):
     except Exception as e:
         logging.error(f'ERR:{myself()}: invalid tx info ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid tx info ({e})')
+
 
 # request by CMC
 @r.get("/emissionAmount/{tokenId}", name="blockchain:emissionAmount")
@@ -137,10 +141,12 @@ def getEmmissionAmount(tokenId):
         logging.error(f'ERR:{myself()}: invalid getEmmissionAmount request ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid getEmmissionAmount request ({e})')
 
+
 @r.get("/ergusdoracle", name="blockchain:ergusdoracle")
 async def ergusdoracle():
     res = requests.get("https://erg-oracle-ergusd.spirepools.com/frontendData")
     return json.loads(res.json())
+
 
 # find value from token and address
 def sqlTokenValue(address, token_id, con):
@@ -183,9 +189,10 @@ def sqlTokenValue(address, token_id, con):
     except:
         return 0
 
+
 # paideia tokenId: 1fd6e032e8476c4aa54c18c1a308dce83940e8f4a28f576440513ed7326ad489
 @r.get("/paideiaInCirculation", name="blockchain:paideiaInCirculation")
-def paideiaInCirculation():
+async def paideiaInCirculation():
     # check cache
     cached = cache.get("get_api_blockchain_paideia_in_circulation")
     if cached:
@@ -197,17 +204,13 @@ def paideiaInCirculation():
         logging.debug(f'TOTAL_SUPPLY_PAIDEIA_IN_CIRC: {supply}')
 
         token_id = '1fd6e032e8476c4aa54c18c1a308dce83940e8f4a28f576440513ed7326ad489'
-
         stakePool = 0
-
         address = '2k6J5ocjeESe4cuXP6rwwq55t6cUwiyqDzNdEFgnKhwnWhttnSShZb4LaMmqTndrog6MbdT8iJbnnwWEcNoeRfEqXBQW4ohBTgm8rDnu9WBBZSixjJoKPT4DStGSobBkoxS4HZMe4brCgujdnmnMBNf8s4cfGtJsxRqGwtLMvmP6Z6FAXw5pYveHRFDBZkhh6qbqoetEKX7ER2kJormhK266bPDQPmFCcsoYRdRiUJBtLoQ3fq4C6N2Mtb3Jab4yqjvjLB7JRTP82wzsXNNbjUsvgCc4wibpMc8MqJutkh7t6trkLmcaH12mAZBWiVhwHkCYCjPFcZZDbr7xeh29UDcwPQdApxHyrWTWHtNRvm9dpwMRjnG2niddbZU82Rpy33cMcN3cEYZajWgDnDKtrtpExC2MWSMCx5ky3t8C1CRtjQYX2yp3x6ZCRxG7vyV7UmfDHWgh9bvU'
         vested  = sqlTokenValue(address, token_id, con)
         logging.debug(f'paideia vested: {vested}')
 
         reserved = 0
-
         emitted = 0
-
         paideiaInCirculation = supply - stakePool - vested - reserved - emitted
 
         # set cache
@@ -218,9 +221,10 @@ def paideiaInCirculation():
         logging.error(f'ERR:{myself()}: invalid paideiaInCirculation request ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid paideiaInCirculation request ({e})')
 
+
 # request by CMC/coingecko (3/7/2022)
 @r.get("/ergopadInCirculation", name="blockchain:ergopadInCirculation")
-def ergopadInCirculation():
+async def ergopadInCirculation():
     try:
         # check cache
         cached = cache.get("get_api_blockchain_ergopad_in_circulation")
@@ -264,9 +268,10 @@ def ergopadInCirculation():
         logging.error(f'ERR:{myself()}: invalid ergopadInCirculation request ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid ergopadInCirculation request ({e})')
 
+
 # request by CMC/coingecko (3/7/2022)
 @r.get("/totalSupply/{tokenId}", name="blockchain:totalSupply")
-def totalSupply(tokenId):
+async def totalSupply(tokenId):
     # check cache
     cached = cache.get(f"get_api_blockchain_total_supply_{tokenId}")
     if cached:
@@ -309,16 +314,6 @@ def totalSupply(tokenId):
         logging.error(f'ERR:{myself()}: invalid totalSupply request ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid totalSupply request ({e})')
 
-# assember follow info
-@r.get("/followInfo/{followId}", name="blockchain:followInfo")
-def followInfo(followId):
-    try:
-        res = requests.get(f'{CFG.assembler}/result/{followId}')
-        return res.json()
-
-    except Exception as e:
-        logging.error(f'ERR:{myself()}: invalid assembly follow ({e})')
-        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: invalid assembly follow ({e})')
 
 def getInputBoxes(boxes, txFormat: TXFormat):
     if txFormat==TXFormat.NODE:
@@ -349,6 +344,7 @@ def getInputBoxes(boxes, txFormat: TXFormat):
                 })
         return unsignedInputs
     return None
+
 
 def getNFTBox(tokenId: str, allowCached=False, includeMempool=True):
     try:
@@ -410,9 +406,11 @@ def getNFTBox(tokenId: str, allowCached=False, includeMempool=True):
         logging.error(f'ERR:{myself()}: unable to find nft box ({e})')
         return None
 
+
 @r.get("/signingRequest/{txId}", name="blockchain:signingRequest")
 def signingRequest(txId):
     return cache.get(f'ergopay_signing_request_{txId}')
+
 
 # @r.get("/getUnspentBoxesByTokenId/{tokenId}", name='blockchain:getUnspentBoxesByTokenId')
 def getUnspentBoxesByTokenId(tokenId, useExplorerApi=False):
@@ -450,6 +448,7 @@ def getUnspentBoxesByTokenId(tokenId, useExplorerApi=False):
         logging.error(f'ERR:{myself()}: failed to get boxes by token id ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: failed to get boxes by token id ({e})')
 
+
 # GET unspent stake boxes
 # Note: Run with useExplorerApi = True in case local explorer service failure
 def getUnspentStakeBoxes(stakeTokenId: str = STAKE_KEY_ID, stakeAddress: str = STAKE_ADDRESS, useExplorerApi=False):
@@ -469,6 +468,7 @@ def getUnspentStakeBoxes(stakeTokenId: str = STAKE_KEY_ID, stakeAddress: str = S
     else:
         # fast, average response time around 3 seconds
         return getUnspentStakeBoxesFromExplorerDB(stakeTokenId, stakeAddress)
+
 
 # GET unspent boxes by token id direct from explorer db
 def getUnspentStakeBoxesFromExplorerDB(stakeTokenId: str = STAKE_KEY_ID, stakeAddress: str = STAKE_ADDRESS):
@@ -535,6 +535,7 @@ def getUnspentStakeBoxesFromExplorerDB(stakeTokenId: str = STAKE_KEY_ID, stakeAd
         logging.error(f'ERR:{myself()}: failed to read data from explorer db ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: failed to read data from explorer db ({e})')
 
+
 # GET token boxes legacy code using explorer API
 def getTokenBoxes(tokenId: str, offset: int = 0, limit: int = 100, retries: int = 10):
     try:
@@ -552,6 +553,7 @@ def getTokenBoxes(tokenId: str, offset: int = 0, limit: int = 100, retries: int 
     except Exception as e:
         logging.error(f'ERR:{myself()}: unable to find token box ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: unable to find token box ({e})')
+
 
 # find unspent boxes with tokens
 @r.get("/unspentTokens", name="blockchain:unspentTokens")
@@ -601,6 +603,7 @@ def getBoxesWithUnspentTokens(nErgAmount=-1, tokenId=CFG.ergopadTokenId, tokenAm
         logging.error(f'ERR:{myself()}: unable to find unspent tokens ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: unable to find unspent tokens ({e})')
 
+
 # ergoscripts
 @r.get("/script/{name}", name="blockchain:getErgoscript")
 def getErgoscript(name, params={}):
@@ -637,10 +640,12 @@ def getErgoscript(name, params={}):
         logging.error(f'ERR:{myself()}: unable to build script ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: unable to build script ({e})')
 
+
 class AirdropRequest(BaseModel):
     tokenId: str
     submit: bool = False
     addresses: Dict[str,Decimal]
+
 
 @r.post("/airdrop", name="blockchain:airdrop")
 async def airdrop( 
@@ -666,22 +671,20 @@ async def airdrop(
         ))
     
     feeRequired = max(int(1e6),int(len(outputs)*int(1e5)))
-
     inputs = appKit.boxesToSpend(CFG.ergopadWallet,nErgRequired+feeRequired,{req.tokenId: tokensRequired})
-
     unsignedTx = appKit.buildUnsignedTransaction(
         inputs=inputs,
         outputs=outputs,
         fee=feeRequired,
         sendChangeTo=appKit.contractFromAddress(CFG.ergopadWallet).toAddress().getErgoAddress()
     )
-
     signedTx = appKit.signTransactionWithNode(unsignedTx)
 
     if req.submit:
         return appKit.sendTransaction(signedTx)
     
     return ErgoAppKit.unsignedTxToJson(unsignedTx)
+
 
 @r.get("/tvl/{tokenId}", name="blockchain:tvl")
 async def tvl(tokenId: str):
@@ -729,4 +732,5 @@ async def tvl(tokenId: str):
     except Exception as e:
         logging.error(f'ERR:{myself()}: unable to determine TVL ({e})')
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'ERR:{myself()}: unable to determine TVL.')
+
 #endregion ROUTES

--- a/app/api/v1/routes/staking.py
+++ b/app/api/v1/routes/staking.py
@@ -891,7 +891,9 @@ async def stakingStatus(project: str):
 @r.post("/{project}/staked/", name="staking:staked-v2")
 async def stakedv2(project: str, req: AddressList):
     if project in stakingConfigsV1:
-            return await staked(req, project)
+        return await staked(req, project)
+    if project in ("paideia",): # use optimized endpoint for paideia
+        return await staked(req, project)
     if project not in stakingConfigs:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{project} does not have a staking config')
 

--- a/app/api/v1/routes/staking.py
+++ b/app/api/v1/routes/staking.py
@@ -842,7 +842,7 @@ async def addstake(project: str, req: UnstakeRequest):
 async def stakingStatus(project: str):
     try:
         if project in stakingConfigsV1:
-            return stakingStatusV1(project)
+            return await stakingStatusV1(project)
         if project not in stakingConfigs:
             return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f'{project} does not have a staking config')
         # check cache

--- a/app/api/v1/routes/vesting.py
+++ b/app/api/v1/routes/vesting.py
@@ -258,7 +258,7 @@ async def redeemToken(address:str, numBoxes:Optional[int]=200):
 # find vesting/vested tokens
 @r.get("/vested/{wallet}", name="vesting:findVestedTokens")
 async def findVestingTokens(wallet:str):
-    CACHE_TTL = 1800 # 30 mins (this is only changed once per month)
+    CACHE_TTL = 3600 # 60 mins (this is only changed once per month)
     try:
         # check cache first
         cached = cache.get(f"get_vesting_vested_ergopad_{wallet}")
@@ -479,7 +479,7 @@ async def redeemWithNFT(req: RedeemWithNFTRequest):
 
 @r.post("/vestedWithNFT/", name="vesting:vestedWithNFT")
 async def vested(req: AddressList):
-    CACHE_TTL = 600 # 10 mins
+    CACHE_TTL = 1800 # 30 mins (invalidated by invalidation service on change)
     vestingAddresses = [
         '2k6J5ocjeESe4cuXP6rwwq55t6cUwiyqDzNdEFgnKhwnWhttnSShZb4LaMmqTndrog6MbdT8iJbnnwWEcNoeRfEqXBQW4ohBTgm8rDnu9WBBZSixjJoKPT4DStGSobBkoxS4HZMe4brCgujdnmnMBNf8s4cfGtJsxRqGwtLMvmP6Z6FAXw5pYveHRFDBZkhh6qbqoetEKX7ER2kJormhK266bPDQPmFCcsoYRdRiUJBtLoQ3fq4C6N2Mtb3Jab4yqjvjLB7JRTP82wzsXNNbjUsvgCc4wibpMc8MqJutkh7t6trkLmcaH12mAZBWiVhwHkCYCjPFcZZDbr7xeh29UDcwPQdApxHyrWTWHtNRvm9dpwMRjnG2niddbZU82Rpy33cMcN3cEYZajWgDnDKtrtpExC2MWSMCx5ky3t8C1CRtjQYX2yp3x6ZCRxG7vyV7UmfDHWgh9bvU',
         'HNLdwoHRsUSevguzRajzvy1DLAvUJ9YgQezQq6GGZiY4TmU9VDs2ae8mRpQkfEnLmuUKyJibZD2bXR2yoo1p8T5WCRKPn4rJVJ2VR2LvRBk8ViCmhcume5ubWaySXTUqpftEaaURTM6KSFxe4QbRFbToyPzZ3JJmjoDn4WzHh5ioXZMj7AX6xTwJvFmzPuko9BqDk5z1RJtD1wP4kd8sSsLN9P2YNQxmUGDEBYHaDCoAhY7Pg5oKit6ZyqMynoiycWqctfg1EHhMUKCTJsZNnidU961ri98RaYP4CfEwYQ3d9dRVuC6S1n7J1wPPHYqmUBgJCGWbTULayXUowSSmRuZUkQYGo9vvNaEpB7ManiLsX1n8cBYwN4XoVsY24mCfptBP86P4rZ5fgcr9mYtQ9nG934DMDZBbjs81VzCupB6KVrGCe1WtYSr6c1DwkNAinBMwqcqxTznXZUvfBsjDSCtJzCut44xcc7Zsy9mWz2B2pqhdKsX83BVzMDDM5hnjXTShYfauJGs81']


### PR DESCRIPTION
## redirect staked-v2 endpoint to use optimized staked v1 endpoint for paideia 
- POST ```staking/paideia/staked``` uses ergopad-unspent
 
### other improvements
- fixes ```staking/egio/status``` call
- increases cache TTL for vested endpoints as cache invalidator service invalidates the cache when a transaction is confirmed on chain
- removes caching overhead from get asset balance (no signficant improvement observed with caching but invalidation has significant overhead)
- adds async to token page endpoints
